### PR TITLE
docs(adventure-04): note port 8080 must be set to public

### DIFF
--- a/adventures/04-blind-by-design/docs/beginner.md
+++ b/adventures/04-blind-by-design/docs/beginner.md
@@ -86,6 +86,8 @@ Before you open the forwarded port, start the Spring Boot lab so it is actually 
 
 The lab boots in the broken state — `Trial` returns the hard-coded `"untreated"` literal — and that is exactly the starting point you want.
 
+> **Set port 8080 to Public.** In the **Ports** tab, right-click port `8080` and set its visibility to **Public** so the forwarded address is accessible in your browser.
+
 ### 3. Access the UI
 
 Open the **Ports** tab in the bottom panel. You should see:


### PR DESCRIPTION
- Players need the forwarded port visible in their browser to test the lab; without setting it to Public the address is inaccessible.

## What does this PR do?
## Type of PR

- [ ] 💡 Adventure Idea
- [ ] 🗺️ New Adventure Level
- [ ] 📖 Solution Walkthrough
- [ ] 🐛 Bug fix / 📝 Documentation improvement / Other

---

