### PR TITLE
feat(devcontainer): auto-fork repo on Codespace create

### DIFF
--- a/.devcontainer/00-blind-by-design_02-intermediate/post-create.sh
+++ b/.devcontainer/00-blind-by-design_02-intermediate/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "00-blind-by-design" "intermediate"

--- a/.devcontainer/01-echoes-lost-in-orbit_beginner/post-create.sh
+++ b/.devcontainer/01-echoes-lost-in-orbit_beginner/post-create.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 lib/shared/init.sh --version v0.17.0 # https://github.com/charmbracelet/gum/releases
 # kind: https://github.com/kubernetes-sigs/kind/releases | kubectl: https://dl.k8s.io | kubens: https://github.com/ahmetb/kubectx/releases | k9s: https://github.com/derailed/k9s/releases | helm: https://github.com/helm/helm/releases
 lib/kubernetes/init.sh \

--- a/.devcontainer/01-echoes-lost-in-orbit_expert/post-create.sh
+++ b/.devcontainer/01-echoes-lost-in-orbit_expert/post-create.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 lib/shared/init.sh --version v0.17.0 # https://github.com/charmbracelet/gum/releases
 # kind: https://github.com/kubernetes-sigs/kind/releases | kubectl: https://dl.k8s.io | kubens: https://github.com/ahmetb/kubectx/releases | k9s: https://github.com/derailed/k9s/releases | helm: https://github.com/helm/helm/releases
 lib/kubernetes/init.sh \

--- a/.devcontainer/01-echoes-lost-in-orbit_intermediate/post-create.sh
+++ b/.devcontainer/01-echoes-lost-in-orbit_intermediate/post-create.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 lib/shared/init.sh --version v0.17.0 # https://github.com/charmbracelet/gum/releases
 # kind: https://github.com/kubernetes-sigs/kind/releases | kubectl: https://dl.k8s.io | kubens: https://github.com/ahmetb/kubectx/releases | k9s: https://github.com/derailed/k9s/releases | helm: https://github.com/helm/helm/releases
 lib/kubernetes/init.sh \

--- a/.devcontainer/02-building-cloudhaven_01-beginner/post-create.sh
+++ b/.devcontainer/02-building-cloudhaven_01-beginner/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "02-building-cloudhaven" "beginner"

--- a/.devcontainer/02-building-cloudhaven_02-intermediate/post-create.sh
+++ b/.devcontainer/02-building-cloudhaven_02-intermediate/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "02-building-cloudhaven" "intermediate"

--- a/.devcontainer/02-building-cloudhaven_03-expert/post-create.sh
+++ b/.devcontainer/02-building-cloudhaven_03-expert/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "02-building-cloudhaven" "expert"

--- a/.devcontainer/03-the-ai-observatory_01-beginner/post-create.sh
+++ b/.devcontainer/03-the-ai-observatory_01-beginner/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "03-the-ai-observatory" "beginner"

--- a/.devcontainer/03-the-ai-observatory_02-intermediate/post-create.sh
+++ b/.devcontainer/03-the-ai-observatory_02-intermediate/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "03-the-ai-observatory" "intermediate"

--- a/.devcontainer/03-the-ai-observatory_03-expert/post-create.sh
+++ b/.devcontainer/03-the-ai-observatory_03-expert/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "03-the-ai-observatory" "expert"

--- a/.devcontainer/04-blind-by-design_01-beginner/post-create.sh
+++ b/.devcontainer/04-blind-by-design_01-beginner/post-create.sh
@@ -4,6 +4,11 @@ set -e
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CHALLENGE_DIR="$REPO_ROOT/adventures/04-blind-by-design/beginner"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "04-blind-by-design" "beginner"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 lib/shared/init.sh --version v0.17.0 # https://github.com/charmbracelet/gum/releases
 
 echo "→ Installing mkdocs-material..."

--- a/adventures/planned/00-lex-imperfecta/beginner/.devcontainer/00-lex-imperfecta_01-beginner/post-create.sh
+++ b/adventures/planned/00-lex-imperfecta/beginner/.devcontainer/00-lex-imperfecta_01-beginner/post-create.sh
@@ -3,6 +3,11 @@ set -e
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# Fork the repo into the user's account if running inside a Codespace.
+if [[ "${CODESPACES:-}" == "true" ]]; then
+  gh repo fork --clone=false --remote=false || true
+fi
+
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "lex-imperfecta" "beginner"


### PR DESCRIPTION
- Add gh repo fork to every post-create.sh so a personal fork is created automatically when a player opens a Codespace.
- Guard with CODESPACES=true so the block is skipped in local dev.
- Use --clone=false --remote=false to avoid side effects on the working directory; || true tolerates an already-existing fork.

## What does this PR do?

<!-- Brief description -->

Closes #<!-- issue number, if applicable -->

## Type of PR

- [ ] 💡 Adventure Idea
- [ ] 🗺️ New Adventure Level
- [ ] 📖 Solution Walkthrough
- [x] 🐛 Bug fix / 📝 Documentation improvement / Other


