### PR TITLE
docs: support local execution for Adventure 01

### DIFF
--- a/.devcontainer/01-echoes-lost-in-orbit_beginner/post-start.sh
+++ b/.devcontainer/01-echoes-lost-in-orbit_beginner/post-start.sh
@@ -3,13 +3,17 @@ set -e
 
 echo "✨ Starting level 1 - Beginner"
 
-REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/scripts/repository-url.sh"
+
+REPO_URL="$(get_repository_url)"
+echo "Using repository URL: $REPO_URL"
 sed -i "s|__REPO_URL__|${REPO_URL}|g" adventures/01-echoes-lost-in-orbit/beginner/manifests/appset.yaml
 
 kubectl apply -n argocd -f adventures/01-echoes-lost-in-orbit/beginner/manifests/appset.yaml
 
 # Track that the environment is ready
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "echoes-lost-in-orbit" "beginner" "01" "12" "2025"

--- a/.devcontainer/01-echoes-lost-in-orbit_expert/post-start.sh
+++ b/.devcontainer/01-echoes-lost-in-orbit_expert/post-start.sh
@@ -2,8 +2,12 @@
 set -e
 
 echo "✨ Starting level 3 - Expert"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/scripts/repository-url.sh"
 
-REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+REPO_URL="$(get_repository_url)"
+echo "Using repository URL: $REPO_URL"
 sed -i "s|__REPO_URL__|${REPO_URL}|g" adventures/01-echoes-lost-in-orbit/expert/manifests/appset.yaml
 
 kubectl apply -n argocd -f adventures/01-echoes-lost-in-orbit/expert/manifests/appset.yaml
@@ -21,7 +25,6 @@ git push
 argocd app get hotrod --refresh
 
 # Track that the environment is ready
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 # shellcheck disable=SC1091
 source "$REPO_ROOT/lib/scripts/tracker.sh"
 set_tracking_context "echoes-lost-in-orbit" "expert" "01" "12" "2025"

--- a/.devcontainer/01-echoes-lost-in-orbit_intermediate/post-start.sh
+++ b/.devcontainer/01-echoes-lost-in-orbit_intermediate/post-start.sh
@@ -3,7 +3,12 @@ set -e
 
 echo "✨ Starting level 2 - Intermediate"
 
-REPO_URL="https://github.com/${GITHUB_REPOSITORY}.git"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/lib/scripts/repository-url.sh"
+
+REPO_URL="$(get_repository_url)"
+echo "Using repository URL: $REPO_URL"
 sed -i "s|__REPO_URL__|${REPO_URL}|g" adventures/01-echoes-lost-in-orbit/intermediate/manifests/appset.yaml
 
 kubectl apply -n argocd -f adventures/01-echoes-lost-in-orbit/intermediate/manifests/appset.yaml

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ headaches.
 - ✅ **Two-step verification** - Smoke tests and GitHub Actions validate your solution
 - 🎓 **Three levels** - Beginner, Intermediate, and Expert for each adventure
 
-## 🚀 Ready to Start?
 ## 💻 Run locally
 
 The challenge environments can also be opened locally using VS Code Dev Containers.

--- a/README.md
+++ b/README.md
@@ -17,5 +17,37 @@ headaches.
 - 🎓 **Three levels** - Beginner, Intermediate, and Expert for each adventure
 
 ## 🚀 Ready to Start?
+## 💻 Run locally
+
+The challenge environments can also be opened locally using VS Code Dev Containers.
+
+### Requirements
+
+- Docker Desktop or another Docker-compatible runtime
+- Visual Studio Code
+- The Dev Containers extension: `ms-vscode-remote.remote-containers`
+- Git
+
+### Start a challenge locally
+
+1. Fork and clone this repository.
+2. Open the repository folder in Visual Studio Code.
+3. Open the Command Palette.
+4. Select **Dev Containers: Reopen in Container**.
+5. Choose the configuration for the adventure and difficulty level you want to run.
+6. Wait for the container's `postCreateCommand` and `postStartCommand` to finish.
+
+The container installs and starts the infrastructure required by the selected challenge.
+
+### Repository detection
+
+In GitHub Codespaces, the repository is detected through the
+`GITHUB_REPOSITORY` environment variable.
+
+When running locally, Adventure 01 derives the repository URL from the local
+`origin` Git remote. GitHub SSH remotes such as:
+
+```text
+git@github.com:username/open-source-challenges.git
 
 [Choose your adventure](https://offon.dev/adventures/) and begin learning!

--- a/lib/scripts/repository-url.sh
+++ b/lib/scripts/repository-url.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+get_repository_url() {
+  if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
+    printf 'https://github.com/%s.git\n' "$GITHUB_REPOSITORY"
+    return
+  fi
+
+  local origin_url
+  origin_url="$(git remote get-url origin)"
+
+  if [[ "$origin_url" =~ ^git@github\.com:(.+)$ ]]; then
+    printf 'https://github.com/%s\n' "${BASH_REMATCH[1]}"
+  else
+    printf '%s\n' "$origin_url"
+  fi
+}


### PR DESCRIPTION
## Summary

- add local VS Code Dev Container instructions
- detect the repository URL locally when GITHUB_REPOSITORY is unavailable
- convert GitHub SSH remotes to HTTPS for Argo CD
- apply the helper to Adventure 01 beginner, intermediate, and expert startup scripts
- document the known Codespaces-only limitation for Adventure 02 Expert

## Testing

- tested Adventure 01 Beginner locally on macOS ARM64
- verified Kind and Argo CD startup
- verified the ApplicationSet uses the fork HTTPS URL
- ran bash syntax checks and git diff --check

Closes #14